### PR TITLE
Support 'new' action for GlobalValueSets, CustomFields, and StandardValueSets

### DIFF
--- a/src/plugins/picklists/index.e2e-spec.ts
+++ b/src/plugins/picklists/index.e2e-spec.ts
@@ -104,6 +104,18 @@ describe(Picklists.name, function() {
       replaceCmd.output.toString()
     );
   });
+  it('should add a new picklist value when it does not exist', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'new.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'picklistValues' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
 });
 
 describe(FieldDependencies.name, function() {

--- a/src/plugins/picklists/index.ts
+++ b/src/plugins/picklists/index.ts
@@ -3,7 +3,7 @@ import { ensureArray } from '../../jsforce-utils';
 import { BrowserforcePlugin } from '../../plugin';
 import { removeEmptyValues } from '../utils';
 import FieldDependencies from './field-dependencies';
-import { PicklistPage } from './pages';
+import { PicklistPage, DefaultPicklistAddPage, StatusPicklistAddPage } from './pages';
 import { determineStandardValueSetEditUrl } from './standard-value-set';
 
 export default class Picklists extends BrowserforcePlugin {
@@ -70,9 +70,11 @@ export default class Picklists extends BrowserforcePlugin {
           ) {
             return true;
           }
-          if (target.newValue && !source.newValueExists && target.metadataType === "StandardValueSet") {
+          if (
+            target.newValue &&
+            !source.newValueExists
+          ) {
             // New value doesn't exist in org yet
-            // TODO: support for CustomFields
             return true;
           }
           return false;
@@ -114,11 +116,14 @@ export default class Picklists extends BrowserforcePlugin {
           );
           await replacePage.replaceAndDelete(action.newValue);
         } else if (!action.value && action.newValue && !action.replaceAllBlankValues) {
-          const addPage = await picklistPage.clickNewActionButton();
-          await addPage.add(
-            action.newValue,
-            action.statusCategory
-          );
+          await picklistPage.clickNewActionButton();
+
+          if (action.statusCategory) {
+            await new StatusPicklistAddPage(page).add(action.newValue, action.statusCategory);
+          } else {
+            await new DefaultPicklistAddPage(page).add(action.newValue);
+          }
+
         } else {
           const replacePage = await picklistPage.clickReplaceActionButton();
           await replacePage.replace(

--- a/src/plugins/picklists/new.json
+++ b/src/plugins/picklists/new.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "picklists": {
+      "picklistValues": [
+        {
+          "metadataType": "StandardValueSet",
+          "metadataFullName": "ContractStatus",
+          "newValue": "Rejected",
+          "statusCategory": "Activated"
+        },
+        {
+          "metadataType": "StandardValueSet",
+          "metadataFullName": "AccountType",
+          "newValue": "Sales Partner"
+        },
+        {
+          "metadataType": "CustomField",
+          "metadataFullName": "Vehicle__c.Features__c",
+          "newValue": "Heated Seats"
+        },
+        {
+          "metadataType": "GlobalValueSet",
+          "metadataFullName": "VehicleGears",
+          "newValue": "10"
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/picklists/pages.ts
+++ b/src/plugins/picklists/pages.ts
@@ -47,15 +47,14 @@ export class PicklistPage {
       })
     ];
   }
-  public async clickNewActionButton(): Promise<any> {
-    const NEW_ACTION_BUTTON_XPATH = '/html[1]/body[1]/div[1]/div[2]/table[1]/tbody[1]/tr[1]/td[2]/div[5]/div[1]/div[1]/div[1]/table[1]/tbody[1]/tr[1]/td[2]/input[1]';
+  public async clickNewActionButton(): Promise<void> {
+    const NEW_ACTION_BUTTON_XPATH = '//tr[td[2]]//input[contains(@onclick, "/setup/ui/picklist_masteredit")][@value=" New "]';
     await this.page.waitForXPath(NEW_ACTION_BUTTON_XPATH);
     const NEW_ACTION_BUTTON = (await this.page.$x(NEW_ACTION_BUTTON_XPATH))[0];
     await Promise.all([
       this.page.waitForNavigation(),
       NEW_ACTION_BUTTON.click()
     ]);
-    return new PicklistAddPage(this.page);
   }
 
   public async clickReplaceActionButton(): Promise<any> {
@@ -122,7 +121,51 @@ export class PicklistPage {
   }
 }
 
-export class PicklistAddPage {
+export class DefaultPicklistAddPage {
+  protected page;
+  protected saveButton = 'input.btn[name="save"]';
+
+  constructor(page) {
+    this.page = page;
+  }
+
+  async add(newValue) {
+    const TEXT_AREA = 'textarea';
+    if (newValue !== undefined && newValue !== null) {
+      await this.page.waitForSelector(TEXT_AREA);
+      await this.page.type(TEXT_AREA, newValue);
+    }
+    await this.save();
+  }
+
+  async save() {
+    await pRetry(
+      async () => {
+        await this.page.waitForSelector(this.saveButton);
+        await Promise.all([
+          this.page.waitForNavigation(),
+          this.page.click(this.saveButton)
+        ]);
+        await throwPageErrors(this.page);
+      },
+      {
+        onFailedAttempt: error => {
+          console.warn(
+            `retrying ${error.retriesLeft} more time(s) because of "${error}"`
+          );
+        },
+        retries: process.env.BROWSERFORCE_RETRY_MAX_RETRIES
+          ? parseInt(process.env.BROWSERFORCE_RETRY_MAX_RETRIES, 10)
+          : 6,
+        minTimeout: process.env.BROWSERFORCE_RETRY_TIMEOUT_MS
+          ? parseInt(process.env.BROWSERFORCE_RETRY_TIMEOUT_MS, 10)
+          : 4000
+      }
+    );
+  }
+}
+
+export class StatusPicklistAddPage {
   protected page;
   protected saveButton = 'input.btn[name="save"]';
 

--- a/src/plugins/picklists/sfdx-source/standardValueSets/AccountType.standardValueSet-meta.xml
+++ b/src/plugins/picklists/sfdx-source/standardValueSets/AccountType.standardValueSet-meta.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StandardValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <sorted>false</sorted>
+    <standardValue>
+        <fullName>Prospect</fullName>
+        <default>false</default>
+        <label>Prospect</label>
+    </standardValue>
+    <standardValue>
+        <fullName>Customer - Direct</fullName>
+        <default>false</default>
+        <label>Customer - Direct</label>
+    </standardValue>
+    <standardValue>
+        <fullName>Customer - Channel</fullName>
+        <default>false</default>
+        <label>Customer - Channel</label>
+    </standardValue>
+    <standardValue>
+        <fullName>Channel Partner / Reseller</fullName>
+        <default>false</default>
+        <label>Channel Partner / Reseller</label>
+    </standardValue>
+    <standardValue>
+        <fullName>Installation Partner</fullName>
+        <default>false</default>
+        <label>Installation Partner</label>
+    </standardValue>
+    <standardValue>
+        <fullName>Technology Partner</fullName>
+        <default>false</default>
+        <label>Technology Partner</label>
+    </standardValue>
+    <standardValue>
+        <fullName>Other</fullName>
+        <default>false</default>
+        <label>Other</label>
+    </standardValue>
+</StandardValueSet>

--- a/src/plugins/picklists/sfdx-source/standardValueSets/ContractStatus.standardValueSet-meta.xml
+++ b/src/plugins/picklists/sfdx-source/standardValueSets/ContractStatus.standardValueSet-meta.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StandardValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <groupingStringEnum>ContractStatusCode</groupingStringEnum>
+    <sorted>false</sorted>
+    <standardValue>
+        <fullName>In Approval Process</fullName>
+        <default>false</default>
+        <label>In Approval Process</label>
+        <groupingString>InApproval</groupingString>
+    </standardValue>
+    <standardValue>
+        <fullName>Activated</fullName>
+        <default>false</default>
+        <label>Activated</label>
+        <groupingString>Activated</groupingString>
+    </standardValue>
+    <standardValue>
+        <fullName>Draft</fullName>
+        <default>false</default>
+        <label>Draft</label>
+        <groupingString>Draft</groupingString>
+    </standardValue>
+</StandardValueSet>


### PR DESCRIPTION
- Revised 'new' action button xpath to support global value sets, custom fields, and standard value sets other than ContractStatus.

- Add unit test for 'new' action